### PR TITLE
fix bare JSON references in specs to use Legion::JSON (LegionIO/legion-json#2)

### DIFF
--- a/spec/legion/tty/app_spec.rb
+++ b/spec/legion/tty/app_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe Legion::TTY::App do
       Dir.mktmpdir do |dir|
         app = described_class.new(config_dir: dir)
         app.send(:save_config, { name: 'Matt', provider: 'claude', api_key: 'sk-test' })
-        identity = JSON.parse(File.read(File.join(dir, 'identity.json')))
-        expect(identity).not_to have_key('api_key')
+        identity = Legion::JSON.parse(File.read(File.join(dir, 'identity.json')))
+        expect(identity).not_to have_key(:api_key)
       end
     end
 
@@ -101,8 +101,8 @@ RSpec.describe Legion::TTY::App do
       Dir.mktmpdir do |dir|
         app = described_class.new(config_dir: dir)
         app.send(:save_config, { name: 'Matt', provider: 'claude', api_key: 'sk-test' })
-        creds = JSON.parse(File.read(File.join(dir, 'credentials.json')))
-        expect(creds['api_key']).to eq('sk-test')
+        creds = Legion::JSON.parse(File.read(File.join(dir, 'credentials.json')))
+        expect(creds[:api_key]).to eq('sk-test')
       end
     end
   end


### PR DESCRIPTION
## Summary
- Replace 6 bare `JSON.parse`/`JSON.generate` calls with `Legion::JSON.parse`/`Legion::JSON.generate` in spec files
- Fixes CI constant-safety lint failures (bare `JSON` inside Legion namespace)
- Uses legion-json 1.3.0 which now wraps the full stdlib surface

## Changes
- `spec/legion/tty/app_spec.rb` — `JSON.parse` -> `Legion::JSON.parse`, string key expectations updated to symbol keys
- `spec/legion/tty/screens/chat_response_timing_spec.rb` — `JSON.generate` -> `Legion::JSON.generate` (4 occurrences)

## Test Coverage
- 1850 examples, 0 failures
- `bundle exec rubocop` — zero offenses