### PR TITLE
migrate daemon_client to Legion::Logging::Helper, fix kerberos days_in_month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.42] - 2026-04-08
+
+### Changed
+- `DaemonClient` now uses `Legion::Logging::Helper` (structured logging via `log.info`/`log.debug`) instead of inline `Legion::Logging.method if defined?` guards for all logging and exception handling
+- Bumped `legion-logging` minimum dependency from `>= 1.2.8` to `>= 1.5.0` to use `handle_exception` from `Legion::Logging::Helper`
+- Extracted `store_manifest` and `parse_inference_response` private helpers to reduce method complexity in `fetch_manifest` and `inference`
+
+### Fixed
+- `KerberosProbe#days_in_month` used `Time.new(year, month, -1)` which raises `ArgumentError` for day `-1`; replaced with `Date.new(year, month, -1).day` (correct Ruby idiom for last day of month)
+
 ## [0.4.41] - 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Rich terminal UI for the LegionIO async cognition engine. Provides onboarding wi
 
 **GitHub**: https://github.com/LegionIO/legion-tty
 **Gem**: `legion-tty`
-**Version**: 0.4.41
+**Version**: 0.4.42
 **License**: Apache-2.0
 **Ruby**: >= 3.4
 
@@ -128,8 +128,8 @@ lib/legion/tty/
 
 ```bash
 bundle install
-bundle exec rspec       # 1850 examples, 0 failures
-bundle exec rubocop     # 156 files, 0 offenses
+bundle exec rspec       # 1952 examples, 0 failures
+bundle exec rubocop     # 163 files, 0 offenses
 ```
 
 ## Pre-Push Pipeline

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Rich terminal UI for the LegionIO async cognition engine.
 
-**Version**: 0.4.35
+**Version**: 0.4.42
 
 Think Claude Code meets Codex CLI, but for LegionIO: onboarding wizard with identity detection, streaming AI chat shell with 115 slash commands, operational dashboard, extensions browser, config editor, and session persistence - all rendered with the [tty-ruby](https://ttytoolkit.org/) gem ecosystem.
 
@@ -289,8 +289,8 @@ Boot logs go to `~/.legionio/logs/tty-boot.log`.
 
 ```bash
 bundle install
-bundle exec rspec       # 1817 examples, 0 failures
-bundle exec rubocop     # 150 files, 0 offenses
+bundle exec rspec       # 1952 examples, 0 failures
+bundle exec rubocop     # 163 files, 0 offenses
 ```
 
 ## License

--- a/legion-tty.gemspec
+++ b/legion-tty.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bootsnap', '>= 1.18'
   spec.add_dependency 'legion-json', '>= 1.2.0'
-  spec.add_dependency 'legion-logging', '>= 1.2.8'
+  spec.add_dependency 'legion-logging', '>= 1.5.0'
 
   # spec.add_dependency 'legion-rbac', '~> 0.2'
   # spec.add_dependency 'lex-kerberos', '~> 0.1'

--- a/lib/legion/tty/background/kerberos_probe.rb
+++ b/lib/legion/tty/background/kerberos_probe.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require 'resolv'
 require 'shellwords'
 
@@ -185,7 +186,7 @@ module Legion
         # rubocop:enable Metrics/AbcSize
 
         def days_in_month(month, year)
-          Time.new(year, month, -1).day
+          Date.new(year, month, -1).day
         end
 
         def log_result(result, elapsed)

--- a/lib/legion/tty/daemon_client.rb
+++ b/lib/legion/tty/daemon_client.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require 'uri'
 require 'fileutils'
 require 'legion/json'
+require 'legion/logging'
 
 module Legion
   module TTY
@@ -12,11 +13,14 @@ module Legion
 
       # rubocop:disable Metrics/ClassLength
       class << self
+        include Legion::Logging::Helper
+
         def configure(daemon_url: 'http://127.0.0.1:4567', cache_file: nil, timeout: 5)
           @daemon_url = daemon_url
           @cache_file = cache_file || File.expand_path('~/.legionio/catalog.json')
           @timeout = timeout
           @manifest = nil
+          log.info { "TTY daemon client configured daemon_url=#{@daemon_url} timeout=#{@timeout}" }
         end
 
         def available?
@@ -26,7 +30,7 @@ module Legion
           end
           response.code.to_i == 200
         rescue StandardError => e
-          Legion::Logging.debug("daemon available? check failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :debug, operation: 'tty.daemon_client.available?', daemon_url: daemon_url)
           false
         end
 
@@ -37,12 +41,9 @@ module Legion
           end
           return nil unless response.code.to_i == 200
 
-          body = Legion::JSON.load(response.body)
-          @manifest = body[:data]
-          write_cache(@manifest)
-          @manifest
+          store_manifest(Legion::JSON.load(response.body)[:data])
         rescue StandardError => e
-          Legion::Logging.warn("fetch_manifest failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: 'tty.daemon_client.fetch_manifest', daemon_url: daemon_url)
           nil
         end
 
@@ -53,7 +54,7 @@ module Legion
 
           @manifest = Legion::JSON.load(File.read(@cache_file))
         rescue StandardError => e
-          Legion::Logging.warn("cached_manifest failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: 'tty.daemon_client.cached_manifest', cache_file: @cache_file)
           nil
         end
 
@@ -80,26 +81,28 @@ module Legion
 
           uri = URI("#{daemon_url}/api/llm/chat")
           payload = Legion::JSON.dump({ message: message, model: model, provider: provider })
+          log.debug { "TTY chat request model=#{model} provider=#{provider} message_length=#{message.to_s.length}" }
           response = post_json(uri, payload)
 
           return nil unless response && SUCCESS_CODES.include?(response.code.to_i)
 
           Legion::JSON.load(response.body)
         rescue StandardError => e
-          Legion::Logging.warn("chat failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: 'tty.daemon_client.chat',
+                              daemon_url: daemon_url, model: model, provider: provider)
           nil
         end
 
         def inference(messages:, tools: [], model: nil, provider: nil, timeout: 120)
+          log.debug { "TTY inference model=#{model} provider=#{provider} msgs=#{Array(messages).size}" }
           response = post_inference(messages: messages, tools: tools, model: model,
                                     provider: provider, timeout: timeout)
           return inference_error_result(response) unless SUCCESS_CODES.include?(response.code.to_i)
 
-          body = Legion::JSON.load(response.body)
-          data = body[:data] || body
-          { status: :ok, data: data }
+          parse_inference_response(response)
         rescue StandardError => e
-          Legion::Logging.warn("inference failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: 'tty.daemon_client.inference',
+                              daemon_url: daemon_url, model: model, provider: provider, timeout: timeout)
           { status: :unavailable, error: { message: e.message } }
         end
 
@@ -111,6 +114,19 @@ module Legion
         end
 
         private
+
+        def parse_inference_response(response)
+          body = Legion::JSON.load(response.body)
+          data = body[:data] || body
+          { status: :ok, data: data }
+        end
+
+        def store_manifest(data)
+          @manifest = data
+          write_cache(@manifest)
+          log.info { "TTY fetched daemon manifest entries=#{Array(@manifest).size}" }
+          @manifest
+        end
 
         def post_inference(messages:, tools:, model:, provider:, timeout:)
           uri = URI("#{daemon_url}/api/llm/inference")
@@ -151,8 +167,9 @@ module Legion
 
           FileUtils.mkdir_p(File.dirname(@cache_file))
           File.write(@cache_file, Legion::JSON.dump(data))
+          log.debug { "TTY daemon manifest cache updated file=#{@cache_file}" }
         rescue StandardError => e
-          Legion::Logging.warn("write_cache failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: 'tty.daemon_client.write_cache', cache_file: @cache_file)
           nil
         end
       end

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.4.41'
+    VERSION = '0.4.42'
   end
 end


### PR DESCRIPTION
## Summary

- Replaces all inline `Legion::Logging.method if defined?` guards in `DaemonClient` with structured logging via `Legion::Logging::Helper` (`log.info`/`log.debug`/`handle_exception`)
- Bumps `legion-logging` minimum dependency from `>= 1.2.8` to `>= 1.5.0` to use `handle_exception`
- Extracts `store_manifest` and `parse_inference_response` private helpers to reduce AbcSize violations in `fetch_manifest` and `inference`
- Fixes `KerberosProbe#days_in_month`: `Time.new(y, m, -1)` raises `ArgumentError` for day `-1`; replaced with `Date.new(y, m, -1).day`

## Test plan

- [ ] `bundle exec rspec` — 1952 examples, 0 failures
- [ ] `bundle exec rubocop` — 163 files, 0 offenses
- [ ] Verify daemon client logs appear structured with `[daemon_client]` prefix in output
- [ ] Verify `calculate_tenure` handles month boundary correctly (no ArgumentError)