### PR TITLE
fix: TUI scrollback — alternate screen, mouse tracking, vim bindings (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.1] - 2026-04-18
+
+### Fixed
+- **Alternate screen buffer** — `App#run_loop` now enables `\e[?1049h` on startup and `\e[?1049l` on shutdown so the TUI no longer pollutes shell scrollback and the prior shell session is restored on exit (closes #20)
+- **Mouse wheel scroll** — enabled SGR mouse tracking (`\e[?1000h` + `\e[?1006h`) and routed wheel-up/wheel-down events to `MessageStream#scroll_up` / `#scroll_down` with 3-line increments (closes #20)
+- **Vim-style scroll bindings** — added `Ctrl+B` (half-page up) and `Ctrl+F` (half-page down) on the Chat screen; wired `Home` / `End` to jump-to-top / jump-to-bottom when the input bar is empty (closes #20)
+- **Scroll hint in status bar** — `scroll_segment` now shows directional arrows (`↑↓ scroll` or `↑ scroll`) alongside the position counter when content overflows the viewport (closes #20)
+- **Help text updated** — added scroll binding reference line to the help overlay
+
 ## [0.5.0] - 2026-04-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Rich terminal UI for the LegionIO async cognition engine. Provides onboarding wi
 
 **GitHub**: https://github.com/LegionIO/legion-tty
 **Gem**: `legion-tty`
-**Version**: 0.4.42
+**Version**: 0.5.1
 **License**: Apache-2.0
 **Ruby**: >= 3.4
 

--- a/lib/legion/tty/app.rb
+++ b/lib/legion/tty/app.rb
@@ -30,7 +30,8 @@ module Legion
         "\e[1~" => :home, "\e[4~" => :end,
         "\x7f" => :backspace, "\b" => :backspace, "\t" => :tab,
         "\x03" => :ctrl_c, "\x04" => :ctrl_d,
-        "\x01" => :ctrl_a, "\x05" => :ctrl_e,
+        "\x01" => :ctrl_a, "\x02" => :ctrl_b,
+        "\x05" => :ctrl_e, "\x06" => :ctrl_f,
         "\x0B" => :ctrl_k, "\x0C" => :ctrl_l, "\x13" => :ctrl_s,
         "\x15" => :ctrl_u
       }.freeze
@@ -151,12 +152,19 @@ module Legion
 
       # --- Event Loop ---
 
+      ENABLE_ALT_SCREEN = "\e[?1049h"
+      DISABLE_ALT_SCREEN = "\e[?1049l"
+      ENABLE_MOUSE = "\e[?1000h\e[?1006h"
+      DISABLE_MOUSE = "\e[?1000h\e[?1006l"
+
       # rubocop:disable Metrics/AbcSize
       def run_loop
         require 'io/console'
 
         @running = true
         @raw_mode = true
+        $stdout.print ENABLE_ALT_SCREEN
+        $stdout.print ENABLE_MOUSE
         $stdout.print cursor.hide
         $stdout.print cursor.clear_screen
 
@@ -175,9 +183,9 @@ module Legion
         nil
       ensure
         @raw_mode = false
+        $stdout.print DISABLE_MOUSE
         $stdout.print cursor.show
-        $stdout.print cursor.move_to(0, terminal_height - 1)
-        $stdout.puts
+        $stdout.print DISABLE_ALT_SCREEN
         shutdown
       end
       # rubocop:enable Metrics/AbcSize
@@ -188,11 +196,15 @@ module Legion
       end
 
       def normalize_key(raw)
+        mouse = parse_sgr_mouse(raw)
+        return mouse if mouse
+
         KEY_MAP[raw] || raw
       end
 
       # --- Key Dispatch ---
 
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def dispatch_key(key)
         if key == :ctrl_c
           @running = false
@@ -213,12 +225,18 @@ module Legion
         active = @screen_manager.active_screen
         return unless active
 
+        if %i[scroll_up scroll_down].include?(key)
+          dispatch_to_screen(active, key)
+          return
+        end
+
         if active.respond_to?(:needs_input_bar?) && active.needs_input_bar? && @input_bar
           dispatch_to_input_screen(active, key)
         else
           dispatch_to_screen(active, key)
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def dispatch_to_input_screen(screen, key)
         result = @input_bar.handle_key(key)
@@ -295,6 +313,19 @@ module Legion
           break if c.ord.between?(0x40, 0x7E)
         end
         seq
+      end
+
+      SGR_MOUSE_RE = /\A\e\[<(\d+);(\d+);(\d+)([Mm])\z/
+
+      def parse_sgr_mouse(raw)
+        match = SGR_MOUSE_RE.match(raw)
+        return nil unless match
+
+        button = match[1].to_i
+        return :scroll_up if button == 64
+        return :scroll_down if button == 65
+
+        nil
       end
 
       # --- Rendering ---

--- a/lib/legion/tty/app.rb
+++ b/lib/legion/tty/app.rb
@@ -36,6 +36,12 @@ module Legion
         "\x15" => :ctrl_u
       }.freeze
 
+      ENABLE_ALT_SCREEN = "\e[?1049h"
+      DISABLE_ALT_SCREEN = "\e[?1049l"
+      ENABLE_MOUSE = "\e[?1000h\e[?1006h"
+      DISABLE_MOUSE = "\e[?1000h\e[?1006l"
+      SGR_MOUSE_RE = /\A\e\[<(\d+);(\d+);(\d+)([Mm])\z/
+
       attr_reader :config, :credentials, :screen_manager, :hotkeys, :llm_chat, :input_bar
 
       def self.run(argv = [])
@@ -152,11 +158,6 @@ module Legion
 
       # --- Event Loop ---
 
-      ENABLE_ALT_SCREEN = "\e[?1049h"
-      DISABLE_ALT_SCREEN = "\e[?1049l"
-      ENABLE_MOUSE = "\e[?1000h\e[?1006h"
-      DISABLE_MOUSE = "\e[?1000h\e[?1006l"
-
       # rubocop:disable Metrics/AbcSize
       def run_loop
         require 'io/console'
@@ -204,7 +205,6 @@ module Legion
 
       # --- Key Dispatch ---
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def dispatch_key(key)
         if key == :ctrl_c
           @running = false
@@ -236,7 +236,6 @@ module Legion
           dispatch_to_screen(active, key)
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def dispatch_to_input_screen(screen, key)
         result = @input_bar.handle_key(key)
@@ -314,8 +313,6 @@ module Legion
         end
         seq
       end
-
-      SGR_MOUSE_RE = /\A\e\[<(\d+);(\d+);(\d+)([Mm])\z/
 
       def parse_sgr_mouse(raw)
         match = SGR_MOUSE_RE.match(raw)

--- a/lib/legion/tty/components/input_bar.rb
+++ b/lib/legion/tty/components/input_bar.rb
@@ -49,10 +49,20 @@ module Legion
           when :left
             @cursor_pos = [@cursor_pos - 1, 0].max
             :handled
-          when :home, :ctrl_a
+          when :home
+            return :pass if @buffer.empty?
+
             @cursor_pos = 0
             :handled
-          when :end, :ctrl_e
+          when :ctrl_a
+            @cursor_pos = 0
+            :handled
+          when :end
+            return :pass if @buffer.empty?
+
+            @cursor_pos = @buffer.length
+            :handled
+          when :ctrl_e
             @cursor_pos = @buffer.length
             :handled
           when :ctrl_u

--- a/lib/legion/tty/components/status_bar.rb
+++ b/lib/legion/tty/components/status_bar.rb
@@ -122,7 +122,8 @@ module Legion
           scroll = @state[:scroll]
           return nil unless scroll.is_a?(Hash) && scroll[:total].to_i > scroll[:visible].to_i
 
-          Theme.c(:muted, "#{scroll[:current]}/#{scroll[:total]}")
+          hint = scroll[:current].to_i.positive? ? "\u2191\u2193 scroll" : "\u2191 scroll"
+          Theme.c(:muted, "#{scroll[:current]}/#{scroll[:total]} #{hint}")
         end
 
         def level_to_priority(level)

--- a/lib/legion/tty/screens/chat.rb
+++ b/lib/legion/tty/screens/chat.rb
@@ -207,12 +207,34 @@ module Legion
           when :page_down
             @message_stream.scroll_down(10)
             :handled
+          when :scroll_up
+            @message_stream.scroll_up(3)
+            :handled
+          when :scroll_down
+            @message_stream.scroll_down(3)
+            :handled
+          when :ctrl_b
+            @message_stream.scroll_up(half_page_lines)
+            :handled
+          when :ctrl_f
+            @message_stream.scroll_down(half_page_lines)
+            :handled
+          when :home
+            @message_stream.scroll_up(@message_stream.messages.size * 5)
+            :handled
+          when :end
+            @message_stream.scroll_down(@message_stream.scroll_offset)
+            :handled
           else
             :pass
           end
         end
 
         private
+
+        def half_page_lines
+          [(terminal_height - 3) / 2, 1].max
+        end
 
         def render_focus(width, height)
           stream_lines = @message_stream.render(width: width, height: [height, 1].max)

--- a/lib/legion/tty/screens/chat.rb
+++ b/lib/legion/tty/screens/chat.rb
@@ -200,34 +200,25 @@ module Legion
         end
 
         def handle_input(key)
+          scroll = handle_scroll_key(key)
+          return scroll if scroll
+
+          :pass
+        end
+
+        def handle_scroll_key(key)
           case key
-          when :page_up
-            @message_stream.scroll_up(10)
-            :handled
-          when :page_down
-            @message_stream.scroll_down(10)
-            :handled
-          when :scroll_up
-            @message_stream.scroll_up(3)
-            :handled
-          when :scroll_down
-            @message_stream.scroll_down(3)
-            :handled
-          when :ctrl_b
-            @message_stream.scroll_up(half_page_lines)
-            :handled
-          when :ctrl_f
-            @message_stream.scroll_down(half_page_lines)
-            :handled
-          when :home
-            @message_stream.scroll_up(@message_stream.messages.size * 5)
-            :handled
-          when :end
-            @message_stream.scroll_down(@message_stream.scroll_offset)
-            :handled
-          else
-            :pass
+          when :page_up      then @message_stream.scroll_up(10)
+          when :page_down    then @message_stream.scroll_down(10)
+          when :scroll_up    then @message_stream.scroll_up(3)
+          when :scroll_down  then @message_stream.scroll_down(3)
+          when :ctrl_b       then @message_stream.scroll_up(half_page_lines)
+          when :ctrl_f       then @message_stream.scroll_down(half_page_lines)
+          when :home         then @message_stream.scroll_up(@message_stream.messages.size * 5)
+          when :end          then @message_stream.scroll_down(@message_stream.scroll_offset)
+          else return nil
           end
+          :handled
         end
 
         private

--- a/lib/legion/tty/screens/chat/ui_commands.rb
+++ b/lib/legion/tty/screens/chat/ui_commands.rb
@@ -36,7 +36,8 @@ module Legion
             'TOOLS   : /tools /export /bookmark /pin /pins /alias /snippet /history',
             'UTILS   : /calc /rand',
             '',
-            'Hotkeys: Ctrl+D=dashboard  Ctrl+K=palette  Ctrl+S=sessions  Esc=back'
+            'Hotkeys: Ctrl+D=dashboard  Ctrl+K=palette  Ctrl+S=sessions  Esc=back',
+            'Scroll : Mouse wheel  PgUp/PgDn  Ctrl+B/F (half-page)  Home/End (top/bottom)'
           ].freeze
 
           CALC_SAFE_PATTERN = %r{\A[\d\s+\-*/.()%]*\z}

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
   end
 end

--- a/spec/legion/tty/app_scroll_spec.rb
+++ b/spec/legion/tty/app_scroll_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'legion/tty/app'
+
+RSpec.describe Legion::TTY::App do
+  describe 'terminal escape sequence constants' do
+    it 'defines ENABLE_ALT_SCREEN' do
+      expect(described_class::ENABLE_ALT_SCREEN).to eq("\e[?1049h")
+    end
+
+    it 'defines DISABLE_ALT_SCREEN' do
+      expect(described_class::DISABLE_ALT_SCREEN).to eq("\e[?1049l")
+    end
+
+    it 'defines ENABLE_MOUSE with SGR mode' do
+      expect(described_class::ENABLE_MOUSE).to include("\e[?1000h")
+      expect(described_class::ENABLE_MOUSE).to include("\e[?1006h")
+    end
+
+    it 'defines DISABLE_MOUSE' do
+      expect(described_class::DISABLE_MOUSE).to include("\e[?1006l")
+    end
+
+    it 'defines SGR_MOUSE_RE for parsing mouse events' do
+      expect(described_class::SGR_MOUSE_RE).to be_a(Regexp)
+    end
+  end
+
+  describe 'KEY_MAP additions' do
+    it 'maps ctrl_b (\\x02)' do
+      expect(described_class::KEY_MAP["\x02"]).to eq(:ctrl_b)
+    end
+
+    it 'maps ctrl_f (\\x06)' do
+      expect(described_class::KEY_MAP["\x06"]).to eq(:ctrl_f)
+    end
+  end
+
+  describe '#parse_sgr_mouse' do
+    let(:app) do
+      Dir.mktmpdir do |dir|
+        return described_class.new(config_dir: dir)
+      end
+    end
+
+    it 'returns :scroll_up for wheel up event (button 64)' do
+      result = app.send(:parse_sgr_mouse, "\e[<64;10;20M")
+      expect(result).to eq(:scroll_up)
+    end
+
+    it 'returns :scroll_down for wheel down event (button 65)' do
+      result = app.send(:parse_sgr_mouse, "\e[<65;10;20M")
+      expect(result).to eq(:scroll_down)
+    end
+
+    it 'returns nil for regular mouse click (button 0)' do
+      result = app.send(:parse_sgr_mouse, "\e[<0;10;20M")
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for non-mouse input' do
+      result = app.send(:parse_sgr_mouse, "\e[A")
+      expect(result).to be_nil
+    end
+
+    it 'handles mouse release events (lowercase m)' do
+      result = app.send(:parse_sgr_mouse, "\e[<64;10;20m")
+      expect(result).to eq(:scroll_up)
+    end
+  end
+
+  describe '#normalize_key' do
+    let(:app) do
+      Dir.mktmpdir do |dir|
+        return described_class.new(config_dir: dir)
+      end
+    end
+
+    it 'returns :scroll_up for SGR mouse wheel up' do
+      result = app.send(:normalize_key, "\e[<64;5;10M")
+      expect(result).to eq(:scroll_up)
+    end
+
+    it 'returns :scroll_down for SGR mouse wheel down' do
+      result = app.send(:normalize_key, "\e[<65;5;10M")
+      expect(result).to eq(:scroll_down)
+    end
+
+    it 'falls back to KEY_MAP for regular sequences' do
+      result = app.send(:normalize_key, "\e[A")
+      expect(result).to eq(:up)
+    end
+
+    it 'returns raw key when not in KEY_MAP and not a mouse event' do
+      result = app.send(:normalize_key, 'x')
+      expect(result).to eq('x')
+    end
+  end
+
+  describe '#dispatch_key with scroll events' do
+    let(:app) do
+      Dir.mktmpdir do |dir|
+        return described_class.new(config_dir: dir)
+      end
+    end
+
+    before do
+      app.send(:setup_hotkeys)
+      app.instance_variable_set(:@running, true)
+    end
+
+    it 'dispatches :scroll_up directly to the active screen' do
+      screen = double('screen')
+      allow(screen).to receive(:activate)
+      allow(screen).to receive(:needs_input_bar?).and_return(true)
+      allow(screen).to receive(:handle_input).with(:scroll_up).and_return(:handled)
+      app.screen_manager.push(screen)
+
+      app.send(:dispatch_key, :scroll_up)
+
+      expect(screen).to have_received(:handle_input).with(:scroll_up)
+    end
+
+    it 'dispatches :scroll_down directly to the active screen' do
+      screen = double('screen')
+      allow(screen).to receive(:activate)
+      allow(screen).to receive(:needs_input_bar?).and_return(true)
+      allow(screen).to receive(:handle_input).with(:scroll_down).and_return(:handled)
+      app.screen_manager.push(screen)
+
+      app.send(:dispatch_key, :scroll_down)
+
+      expect(screen).to have_received(:handle_input).with(:scroll_down)
+    end
+  end
+end

--- a/spec/legion/tty/components/input_bar_home_end_spec.rb
+++ b/spec/legion/tty/components/input_bar_home_end_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/tty/components/input_bar'
+
+RSpec.describe Legion::TTY::Components::InputBar, 'Home/End passthrough' do
+  let(:reader) { double('reader', read_line: nil) }
+
+  before { allow(reader).to receive(:on) }
+
+  subject(:bar) { described_class.new(name: 'Test', reader: reader) }
+
+  describe ':home when buffer is empty' do
+    it 'returns :pass so the screen can handle it' do
+      expect(bar.handle_key(:home)).to eq(:pass)
+    end
+  end
+
+  describe ':home when buffer has text' do
+    before { bar.handle_key('h'); bar.handle_key('i') }
+
+    it 'returns :handled and moves cursor to start' do
+      expect(bar.handle_key(:home)).to eq(:handled)
+      expect(bar.cursor_column).to eq(bar.send(:prompt_plain_length))
+    end
+  end
+
+  describe ':end when buffer is empty' do
+    it 'returns :pass so the screen can handle it' do
+      expect(bar.handle_key(:end)).to eq(:pass)
+    end
+  end
+
+  describe ':end when buffer has text' do
+    before { bar.handle_key('h'); bar.handle_key('i') }
+
+    it 'returns :handled and moves cursor to end' do
+      bar.handle_key(:home)
+      expect(bar.handle_key(:end)).to eq(:handled)
+      expect(bar.cursor_column).to eq(bar.send(:prompt_plain_length) + 2)
+    end
+  end
+
+  describe ':ctrl_a always moves to start' do
+    it 'returns :handled even with empty buffer' do
+      expect(bar.handle_key(:ctrl_a)).to eq(:handled)
+    end
+  end
+
+  describe ':ctrl_e always moves to end' do
+    it 'returns :handled even with empty buffer' do
+      expect(bar.handle_key(:ctrl_e)).to eq(:handled)
+    end
+  end
+end

--- a/spec/legion/tty/components/input_bar_home_end_spec.rb
+++ b/spec/legion/tty/components/input_bar_home_end_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Legion::TTY::Components::InputBar, 'Home/End passthrough' do
   end
 
   describe ':home when buffer has text' do
-    before { bar.handle_key('h'); bar.handle_key('i') }
+    before do
+      bar.handle_key('h')
+      bar.handle_key('i')
+    end
 
     it 'returns :handled and moves cursor to start' do
       expect(bar.handle_key(:home)).to eq(:handled)
@@ -32,7 +35,10 @@ RSpec.describe Legion::TTY::Components::InputBar, 'Home/End passthrough' do
   end
 
   describe ':end when buffer has text' do
-    before { bar.handle_key('h'); bar.handle_key('i') }
+    before do
+      bar.handle_key('h')
+      bar.handle_key('i')
+    end
 
     it 'returns :handled and moves cursor to end' do
       bar.handle_key(:home)

--- a/spec/legion/tty/components/status_bar_scroll_hint_spec.rb
+++ b/spec/legion/tty/components/status_bar_scroll_hint_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/tty/components/status_bar'
+
+RSpec.describe Legion::TTY::Components::StatusBar, 'scroll hint' do
+  subject(:bar) { described_class.new }
+
+  describe 'scroll_segment with hint' do
+    it 'shows up-arrow hint when scrolled away from bottom' do
+      bar.update(scroll: { current: 5, total: 20, visible: 10 })
+      result = bar.render(width: 120)
+      plain = result.gsub(/\e\[[0-9;]*m/, '')
+      expect(plain).to include('scroll')
+    end
+
+    it 'includes up and down arrows when offset is positive' do
+      bar.update(scroll: { current: 5, total: 20, visible: 10 })
+      result = bar.render(width: 120)
+      expect(result).to include("\u2191")
+      expect(result).to include("\u2193")
+    end
+
+    it 'shows only up arrow when at bottom (offset 0)' do
+      bar.update(scroll: { current: 0, total: 20, visible: 10 })
+      result = bar.render(width: 120)
+      expect(result).to include("\u2191")
+      expect(result).not_to include("\u2193")
+    end
+
+    it 'does not show scroll hint when all content is visible' do
+      bar.update(scroll: { current: 0, total: 5, visible: 10 })
+      result = bar.render(width: 120)
+      plain = result.gsub(/\e\[[0-9;]*m/, '')
+      expect(plain).not_to include('scroll')
+    end
+  end
+end

--- a/spec/legion/tty/screens/chat_scroll_input_spec.rb
+++ b/spec/legion/tty/screens/chat_scroll_input_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/tty/screens/chat'
+
+RSpec.describe Legion::TTY::Screens::Chat, 'scroll input handling' do
+  let(:output) { StringIO.new }
+  let(:reader) { double('reader', read_line: nil) }
+  let(:input_bar) { Legion::TTY::Components::InputBar.new(name: 'Test', reader: reader) }
+  let(:app) do
+    instance_double('Legion::TTY::App',
+                    config: { provider: 'claude' },
+                    llm_chat: nil,
+                    screen_manager: double('sm', overlay: nil, push: nil, pop: nil, dismiss_overlay: nil,
+                                                 show_overlay: nil),
+                    hotkeys: double('hk', list: []),
+                    respond_to?: true)
+  end
+
+  before do
+    allow(reader).to receive(:on)
+    allow(app).to receive(:respond_to?).with(:config).and_return(true)
+    allow(app).to receive(:respond_to?).with(:llm_chat).and_return(true)
+    allow(app).to receive(:respond_to?).with(:screen_manager).and_return(true)
+    allow(app).to receive(:respond_to?).with(:hotkeys).and_return(true)
+    allow(app).to receive(:respond_to?).with(:toggle_dashboard).and_return(false)
+  end
+
+  subject(:chat) { described_class.new(app, output: output, input_bar: input_bar) }
+
+  before do
+    10.times { |i| chat.message_stream.add_message(role: :user, content: "message #{i}") }
+  end
+
+  describe ':scroll_up (mouse wheel up)' do
+    it 'returns :handled' do
+      expect(chat.handle_input(:scroll_up)).to eq(:handled)
+    end
+
+    it 'increases scroll_offset by 3' do
+      chat.handle_input(:scroll_up)
+      expect(chat.message_stream.scroll_offset).to eq(3)
+    end
+  end
+
+  describe ':scroll_down (mouse wheel down)' do
+    before { chat.message_stream.scroll_up(10) }
+
+    it 'returns :handled' do
+      expect(chat.handle_input(:scroll_down)).to eq(:handled)
+    end
+
+    it 'decreases scroll_offset by 3' do
+      chat.handle_input(:scroll_down)
+      expect(chat.message_stream.scroll_offset).to eq(7)
+    end
+  end
+
+  describe ':ctrl_b (half-page up)' do
+    it 'returns :handled' do
+      expect(chat.handle_input(:ctrl_b)).to eq(:handled)
+    end
+
+    it 'scrolls up by approximately half a page' do
+      chat.handle_input(:ctrl_b)
+      expect(chat.message_stream.scroll_offset).to be > 0
+    end
+  end
+
+  describe ':ctrl_f (half-page down)' do
+    before { chat.message_stream.scroll_up(20) }
+
+    it 'returns :handled' do
+      expect(chat.handle_input(:ctrl_f)).to eq(:handled)
+    end
+
+    it 'scrolls down by approximately half a page' do
+      initial = chat.message_stream.scroll_offset
+      chat.handle_input(:ctrl_f)
+      expect(chat.message_stream.scroll_offset).to be < initial
+    end
+  end
+
+  describe ':home (jump to top)' do
+    it 'returns :handled' do
+      expect(chat.handle_input(:home)).to eq(:handled)
+    end
+
+    it 'sets a large scroll_offset' do
+      chat.handle_input(:home)
+      expect(chat.message_stream.scroll_offset).to be > 0
+    end
+  end
+
+  describe ':end (jump to bottom)' do
+    before { chat.message_stream.scroll_up(20) }
+
+    it 'returns :handled' do
+      expect(chat.handle_input(:end)).to eq(:handled)
+    end
+
+    it 'resets scroll_offset to 0' do
+      chat.handle_input(:end)
+      expect(chat.message_stream.scroll_offset).to eq(0)
+    end
+  end
+
+  describe 'unrecognized keys' do
+    it 'returns :pass' do
+      expect(chat.handle_input(:unknown)).to eq(:pass)
+    end
+  end
+
+  describe ':page_up' do
+    it 'scrolls up by 10' do
+      chat.handle_input(:page_up)
+      expect(chat.message_stream.scroll_offset).to eq(10)
+    end
+  end
+
+  describe ':page_down' do
+    before { chat.message_stream.scroll_up(15) }
+
+    it 'scrolls down by 10' do
+      chat.handle_input(:page_down)
+      expect(chat.message_stream.scroll_offset).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Enable alternate screen buffer (`\e[?1049h`/`\e[?1049l`) so the TUI no longer pollutes shell scrollback and the prior shell session is restored on exit
- Enable SGR mouse tracking (`\e[?1000h` + `\e[?1006h`) — mouse wheel up/down scrolls the chat message stream
- Add vim-style scroll bindings: `Ctrl+B` (half-page up), `Ctrl+F` (half-page down), `Home`/`End` (jump to top/bottom when input is empty)
- Show directional scroll hint (`↑↓ scroll`) in the status bar when content overflows the viewport

Closes #20

## Changes
- `lib/legion/tty/app.rb` — alternate screen buffer on/off in `run_loop`, mouse tracking enable/disable, SGR mouse event parsing, `Ctrl+B`/`Ctrl+F` added to `KEY_MAP`, scroll events bypass input bar dispatch
- `lib/legion/tty/screens/chat.rb` — extracted `handle_scroll_key` with mouse wheel, Ctrl+B/F, Home/End, PgUp/PgDn handlers; added `half_page_lines` helper
- `lib/legion/tty/components/input_bar.rb` — `Home`/`End` pass through to screen when input buffer is empty (Ctrl+A/Ctrl+E retain cursor-move behavior)
- `lib/legion/tty/components/status_bar.rb` — `scroll_segment` shows `↑↓ scroll` or `↑ scroll` hint alongside position counter
- `lib/legion/tty/screens/chat/ui_commands.rb` — added scroll binding reference line to help overlay

## Test Coverage
- 43 new specs across 4 files (2121 total, up from 2078)
- `bundle exec rspec` — 2121 examples, 0 failures
- `bundle exec rubocop` — 170 files, 0 offenses

## Checklist
- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated
- [x] Version bumped to 0.5.1
- [x] No new security concerns introduced