### PR TITLE
fix: bracketed paste support — prevent auto-submit on pasted newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.5.2] - 2026-04-20
+
+### Fixed
+- **Bracketed paste support** — `App#run_loop` now enables bracketed paste mode (`\e[?2004h`) on startup and disables (`\e[?2004l`) on shutdown; `read_csi_sequence` detects `\e[200~` / `\e[201~` paste markers and buffers the full pasted text into a `{ paste: text }` event (closes #22)
+- **InputBar paste handling** — `handle_key` recognizes paste Hash events and inserts the full pasted text at the cursor position, replacing newlines with spaces, without triggering submit (closes #22)
+- **Non-symbol key guard** — `dispatch_key` checks `key.is_a?(Symbol)` before the scroll-event include check, preventing `NoMethodError` on Hash paste events (closes #22)
+- **`normalize_key` paste passthrough** — Hash events (paste) pass through without KEY_MAP lookup (closes #22)
+
 ## [0.5.1] - 2026-04-18
 
 ### Fixed

--- a/lib/legion/tty/app.rb
+++ b/lib/legion/tty/app.rb
@@ -40,6 +40,8 @@ module Legion
       DISABLE_ALT_SCREEN = "\e[?1049l"
       ENABLE_MOUSE = "\e[?1000h\e[?1006h"
       DISABLE_MOUSE = "\e[?1000h\e[?1006l"
+      ENABLE_BRACKETED_PASTE = "\e[?2004h"
+      DISABLE_BRACKETED_PASTE = "\e[?2004l"
       SGR_MOUSE_RE = /\A\e\[<(\d+);(\d+);(\d+)([Mm])\z/
 
       attr_reader :config, :credentials, :screen_manager, :hotkeys, :llm_chat, :input_bar
@@ -158,7 +160,7 @@ module Legion
 
       # --- Event Loop ---
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def run_loop
         require 'io/console'
 
@@ -166,6 +168,7 @@ module Legion
         @raw_mode = true
         $stdout.print ENABLE_ALT_SCREEN
         $stdout.print ENABLE_MOUSE
+        $stdout.print ENABLE_BRACKETED_PASTE
         $stdout.print cursor.hide
         $stdout.print cursor.clear_screen
 
@@ -178,25 +181,38 @@ module Legion
 
             key = normalize_key(raw_key)
             dispatch_key(key)
+            drain_burst_keys(raw_in)
           end
         end
       rescue Interrupt
         nil
       ensure
         @raw_mode = false
+        $stdout.print DISABLE_BRACKETED_PASTE
         $stdout.print DISABLE_MOUSE
         $stdout.print cursor.show
         $stdout.print DISABLE_ALT_SCREEN
         shutdown
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def needs_refresh?
         active = @screen_manager.active_screen
         active.respond_to?(:streaming?) && active.streaming?
       end
 
+      def drain_burst_keys(raw_in)
+        while @running && raw_in.wait_readable(0)
+          burst_key = read_raw_key(raw_in, timeout: 0)
+          break unless burst_key
+
+          dispatch_key(normalize_key(burst_key))
+        end
+      end
+
       def normalize_key(raw)
+        return raw if raw.is_a?(Hash)
+
         mouse = parse_sgr_mouse(raw)
         return mouse if mouse
 
@@ -205,6 +221,7 @@ module Legion
 
       # --- Key Dispatch ---
 
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       def dispatch_key(key)
         if key == :ctrl_c
           @running = false
@@ -225,7 +242,7 @@ module Legion
         active = @screen_manager.active_screen
         return unless active
 
-        if %i[scroll_up scroll_down].include?(key)
+        if key.is_a?(Symbol) && %i[scroll_up scroll_down].include?(key)
           dispatch_to_screen(active, key)
           return
         end
@@ -236,6 +253,7 @@ module Legion
           dispatch_to_screen(active, key)
         end
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
       def dispatch_to_input_screen(screen, key)
         result = @input_bar.handle_key(key)
@@ -311,7 +329,26 @@ module Legion
           seq << c
           break if c.ord.between?(0x40, 0x7E)
         end
+
+        return read_paste_content(io) if seq == "\e[200~"
+
         seq
+      end
+
+      def read_paste_content(io)
+        buf = +''
+        end_marker = "\e[201~"
+        loop do
+          break unless io.wait_readable(1)
+
+          c = io.getc
+          break unless c
+
+          buf << c
+          break if buf.end_with?(end_marker)
+        end
+        buf.delete_suffix!(end_marker)
+        { paste: buf }
       end
 
       def parse_sgr_mouse(raw)

--- a/lib/legion/tty/components/input_bar.rb
+++ b/lib/legion/tty/components/input_bar.rb
@@ -32,6 +32,8 @@ module Legion
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         def handle_key(key)
+          return handle_paste(key[:paste]) if key.is_a?(Hash) && key.key?(:paste)
+
           case key
           when :enter
             submit_line
@@ -199,6 +201,14 @@ module Legion
             @saved_buffer = nil
           end
           @cursor_pos = @buffer.length
+          :handled
+        end
+
+        def handle_paste(text)
+          sanitized = text.to_s.gsub(/\r\n?/, "\n").gsub("\n", ' ')
+          @buffer.insert(@cursor_pos, sanitized)
+          @cursor_pos += sanitized.length
+          @tab_matches = []
           :handled
         end
 

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.5.1'
+    VERSION = '0.5.2'
   end
 end

--- a/spec/legion/tty/app_paste_spec.rb
+++ b/spec/legion/tty/app_paste_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'legion/tty/app'
+
+RSpec.describe Legion::TTY::App, 'bracketed paste' do
+  let(:app) do
+    Dir.mktmpdir do |dir|
+      return described_class.new(config_dir: dir)
+    end
+  end
+
+  describe 'paste constants' do
+    it 'defines ENABLE_BRACKETED_PASTE' do
+      expect(described_class::ENABLE_BRACKETED_PASTE).to eq("\e[?2004h")
+    end
+
+    it 'defines DISABLE_BRACKETED_PASTE' do
+      expect(described_class::DISABLE_BRACKETED_PASTE).to eq("\e[?2004l")
+    end
+  end
+
+  describe '#normalize_key with paste event' do
+    it 'returns a paste hash unchanged' do
+      paste_event = { paste: "line1\nline2" }
+      result = app.send(:normalize_key, paste_event)
+      expect(result).to eq(paste_event)
+    end
+  end
+
+  describe '#dispatch_key with paste event' do
+    before do
+      app.send(:setup_hotkeys)
+      app.instance_variable_set(:@running, true)
+    end
+
+    it 'routes paste events to input bar on input-enabled screens' do
+      input_bar = instance_double(Legion::TTY::Components::InputBar)
+      allow(input_bar).to receive(:handle_key).with({ paste: 'hello' }).and_return(:handled)
+      allow(input_bar).to receive(:cursor_column).and_return(10)
+      app.instance_variable_set(:@input_bar, input_bar)
+
+      screen = double('screen')
+      allow(screen).to receive(:activate)
+      allow(screen).to receive(:needs_input_bar?).and_return(true)
+      app.screen_manager.push(screen)
+
+      app.send(:dispatch_key, { paste: 'hello' })
+      expect(input_bar).to have_received(:handle_key).with({ paste: 'hello' })
+    end
+  end
+end

--- a/spec/legion/tty/components/input_bar_paste_spec.rb
+++ b/spec/legion/tty/components/input_bar_paste_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/tty/components/input_bar'
+
+RSpec.describe Legion::TTY::Components::InputBar, 'paste handling' do
+  subject(:input_bar) { described_class.new(name: 'Alice') }
+
+  describe '#handle_key with paste event' do
+    it 'inserts single-line paste into buffer' do
+      input_bar.handle_key({ paste: 'hello world' })
+      expect(input_bar.buffer).to eq('hello world')
+    end
+
+    it 'inserts multi-line paste replacing newlines with spaces' do
+      input_bar.handle_key({ paste: "line1\nline2\nline3" })
+      expect(input_bar.buffer).to eq('line1 line2 line3')
+    end
+
+    it 'does not trigger submit on paste with newlines' do
+      result = input_bar.handle_key({ paste: "hello\nworld" })
+      expect(result).to eq(:handled)
+      expect(input_bar.buffer).to eq('hello world')
+    end
+
+    it 'inserts paste at cursor position' do
+      input_bar.handle_key('a')
+      input_bar.handle_key('b')
+      input_bar.handle_key(:left)
+      input_bar.handle_key({ paste: 'XY' })
+      expect(input_bar.buffer).to eq('aXYb')
+    end
+
+    it 'handles empty paste gracefully' do
+      result = input_bar.handle_key({ paste: '' })
+      expect(result).to eq(:handled)
+      expect(input_bar.buffer).to eq('')
+    end
+
+    it 'handles paste with carriage returns' do
+      input_bar.handle_key({ paste: "line1\r\nline2" })
+      expect(input_bar.buffer).to eq('line1 line2')
+    end
+
+    it 'appends to existing buffer content' do
+      input_bar.handle_key('>')
+      input_bar.handle_key(' ')
+      input_bar.handle_key({ paste: 'pasted text' })
+      expect(input_bar.buffer).to eq('> pasted text')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #22

- **Bracketed paste mode** enabled on startup (`\e[?2004h`) and disabled on shutdown (`\e[?2004l`) in `App#run_loop`.
- **Paste marker detection** in `read_csi_sequence`: when `\e[200~` is received, `read_paste_content` buffers all bytes until `\e[201~` and returns a `{ paste: text }` Hash event.
- **InputBar paste handling**: `handle_key` detects paste Hash events and delegates to `handle_paste`, which sanitizes newlines (`\r\n` and `\n` → space) and inserts the full pasted text at the cursor position without triggering submit.
- **`normalize_key` guard**: Hash events pass through without KEY_MAP lookup.
- **`dispatch_key` guard**: scroll symbol check now requires `key.is_a?(Symbol)` to avoid `NoMethodError` on Hash paste events.

## Test plan

- [ ] `bundle exec rspec` — all 2132+ examples pass
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] Manual: copy a multi-line code snippet, paste into `legion tty` chat — entire text appears in input bar as single line, no auto-submit
- [ ] Manual: paste with `\r\n` line endings (Windows-style) — converted to spaces correctly
- [ ] Manual: normal Enter key still submits as expected