### PR TITLE
Fix LLM probe routing through Legion LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **LLM provider probe routing** — `Background::LlmProbe` now validates enabled providers through `Legion::LLM.ask` with the configured provider/model instead of calling RubyLLM directly.
+- **Extension catalog provider stack** — the extensions screen now categorizes native `lex-llm-*` provider gems as AI extensions and shows `lex-llm-gateway` as legacy compatibility instead of an active Core extension.
 
 ## [0.5.3] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - **LLM provider probe routing** — `Background::LlmProbe` now validates enabled providers through `Legion::LLM.ask` with the configured provider/model instead of calling RubyLLM directly.
 - **Extension catalog provider stack** — the extensions screen now categorizes native `lex-llm-*` provider gems as AI extensions and shows `lex-llm-gateway` as legacy compatibility instead of an active Core extension.
+- **Development dependency cleanup** — removed the stale direct `ruby_llm` Gemfile dependency so local TTY development follows the Legion-native LLM path.
 
 ## [0.5.3] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.4] - 2026-04-28
+
+### Fixed
+- **LLM provider probe routing** — `Background::LlmProbe` now validates enabled providers through `Legion::LLM.ask` with the configured provider/model instead of calling RubyLLM directly.
+
 ## [0.5.3] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - **LLM provider probe routing** — `Background::LlmProbe` now validates enabled providers through `Legion::LLM.ask` with the configured provider/model instead of calling RubyLLM directly.
 - **Extension catalog provider stack** — the extensions screen now categorizes native `lex-llm-*` provider gems as AI extensions and shows `lex-llm-gateway` as legacy compatibility instead of an active Core extension.
+- **Future native LLM providers** — the extensions screen now classifies future `lex-llm-*` provider gems as AI automatically while preserving `lex-llm-gateway` as Legacy.
 - **Development dependency cleanup** — removed the stale direct `ruby_llm` Gemfile dependency so local TTY development follows the Legion-native LLM path.
 
 ## [0.5.3] - 2026-04-20

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,3 @@ end
 gem 'legionio'
 gem 'legion-rbac'
 gem 'lex-kerberos'
-gem 'ruby_llm'

--- a/lib/legion/tty/app.rb
+++ b/lib/legion/tty/app.rb
@@ -542,7 +542,7 @@ module Legion
 
       def try_settings_llm
         # All LLM calls route through the LegionIO daemon API.
-        # No raw RubyLLM session is created here — nil signals "use daemon path".
+        # No raw provider session is created here; nil signals "use daemon path".
         if Legion::TTY::DaemonClient.available?
           log.debug { 'TTY: daemon available, LLM routed through daemon' }
         else

--- a/lib/legion/tty/background/llm_probe.rb
+++ b/lib/legion/tty/background/llm_probe.rb
@@ -8,6 +8,8 @@ module Legion
       class LlmProbe
         include Legion::Logging::Helper
 
+        PROBE_PROMPT = 'Respond with only: pong'
+
         def initialize(logger: nil, wait_queue: nil)
           @boot_log = logger
           @wait_queue = wait_queue
@@ -76,7 +78,7 @@ module Legion
         def ping_provider(name, config)
           model = config[:default_model]
           start_time = Time.now
-          RubyLLM.chat(model: model, provider: name).ask('Respond with only: pong')
+          Legion::LLM.ask(message: PROBE_PROMPT, model: model, provider: name)
           latency = ((Time.now - start_time) * 1000).round
           { name: name, model: model, status: :ok, latency_ms: latency }
         rescue StandardError => e

--- a/lib/legion/tty/screens/extensions.rb
+++ b/lib/legion/tty/screens/extensions.rb
@@ -121,10 +121,11 @@ module Legion
 
         def categorize(name)
           return 'Core' if CORE.include?(name)
+          return 'Legacy' if LEGACY.include?(name)
+          return 'AI' if name.start_with?('lex-llm-')
           return 'AI' if AI.include?(name)
           return 'Service' if SERVICE.include?(name)
           return 'Agentic' if name.match?(/^lex-agentic-|^lex-theory-|^lex-mind-|^lex-planning|^lex-attention/)
-          return 'Legacy' if LEGACY.include?(name)
 
           'Other'
         end

--- a/lib/legion/tty/screens/extensions.rb
+++ b/lib/legion/tty/screens/extensions.rb
@@ -12,15 +12,20 @@ module Legion
         include Legion::Logging::Helper
 
         CORE = %w[lex-node lex-tasker lex-scheduler lex-conditioner lex-transformer
-                  lex-synapse lex-health lex-log lex-ping lex-metering lex-llm-gateway
+                  lex-synapse lex-health lex-log lex-ping lex-metering lex-llm-ledger
                   lex-codegen lex-exec lex-lex lex-telemetry lex-audit lex-detect].freeze
 
-        AI = %w[lex-claude lex-openai lex-gemini].freeze
+        AI = %w[lex-azure-ai lex-bedrock lex-claude lex-foundry lex-gemini lex-llamacpp
+                lex-mlx lex-ollama lex-openai lex-uais lex-xai lex-llm lex-llm-anthropic
+                lex-llm-azure-foundry lex-llm-bedrock lex-llm-gemini lex-llm-mlx
+                lex-llm-ollama lex-llm-openai lex-llm-vertex lex-llm-vllm].freeze
+
+        LEGACY = %w[lex-llm-gateway].freeze
 
         SERVICE = %w[lex-http lex-vault lex-github lex-consul lex-kerberos lex-tfe
                      lex-redis lex-memcached lex-elasticsearch lex-s3].freeze
 
-        CATEGORIES = [nil, 'Core', 'AI', 'Service', 'Agentic', 'Other'].freeze
+        CATEGORIES = [nil, 'Core', 'AI', 'Service', 'Agentic', 'Legacy', 'Other'].freeze
 
         def initialize(app, output: $stdout)
           super(app)
@@ -119,6 +124,7 @@ module Legion
           return 'AI' if AI.include?(name)
           return 'Service' if SERVICE.include?(name)
           return 'Agentic' if name.match?(/^lex-agentic-|^lex-theory-|^lex-mind-|^lex-planning|^lex-attention/)
+          return 'Legacy' if LEGACY.include?(name)
 
           'Other'
         end

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.5.3'
+    VERSION = '0.5.4'
   end
 end

--- a/spec/legion/tty/background/llm_probe_spec.rb
+++ b/spec/legion/tty/background/llm_probe_spec.rb
@@ -67,36 +67,45 @@ RSpec.describe Legion::TTY::Background::LlmProbe do
   describe '#ping_provider' do
     let(:config) { { default_model: 'claude-3-haiku' } }
 
-    def stub_ruby_llm_success
-      chat_dbl = double('chat', ask: 'pong')
-      ruby_llm_mod = Module.new { def self.chat(**_kwargs); end }
-      allow(ruby_llm_mod).to receive(:chat).and_return(chat_dbl)
-      stub_const('RubyLLM', ruby_llm_mod)
+    def stub_legion_llm_success
+      llm_mod = Module.new { def self.ask(**_kwargs); end }
+      allow(llm_mod).to receive(:ask).and_return({ status: :done, response: 'pong' })
+      stub_const('Legion::LLM', llm_mod)
     end
 
-    def stub_ruby_llm_error(message)
+    def stub_legion_llm_error(message)
       err = message
-      ruby_llm_mod = Module.new { def self.chat(**_kwargs); end }
-      allow(ruby_llm_mod).to receive(:chat).and_raise(StandardError, err)
-      stub_const('RubyLLM', ruby_llm_mod)
+      llm_mod = Module.new { def self.ask(**_kwargs); end }
+      allow(llm_mod).to receive(:ask).and_raise(StandardError, err)
+      stub_const('Legion::LLM', llm_mod)
     end
 
-    it 'returns :ok status when RubyLLM succeeds' do
-      stub_ruby_llm_success
+    it 'returns :ok status when Legion::LLM.ask succeeds' do
+      stub_legion_llm_success
       result = probe.send(:ping_provider, :claude, config)
       expect(result[:status]).to eq(:ok)
       expect(result[:name]).to eq(:claude)
     end
 
-    it 'returns :configured status when RubyLLM raises' do
-      stub_ruby_llm_error('unknown provider')
+    it 'passes provider and model to Legion::LLM.ask' do
+      stub_legion_llm_success
+      probe.send(:ping_provider, :claude, config)
+      expect(Legion::LLM).to have_received(:ask).with(
+        message: 'Respond with only: pong',
+        model: 'claude-3-haiku',
+        provider: :claude
+      )
+    end
+
+    it 'returns :configured status when Legion::LLM.ask raises' do
+      stub_legion_llm_error('unknown provider')
       result = probe.send(:ping_provider, :foundry, config)
       expect(result[:status]).to eq(:configured)
       expect(result[:error]).to eq('unknown provider')
     end
 
     it 'includes latency_ms in all outcomes' do
-      stub_ruby_llm_error('err')
+      stub_legion_llm_error('err')
       result = probe.send(:ping_provider, :xai, config)
       expect(result).to have_key(:latency_ms)
     end

--- a/spec/legion/tty/screens/chat_daemon_spec.rb
+++ b/spec/legion/tty/screens/chat_daemon_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Legion::TTY::Screens::Chat do
           .with("\n[Error: connection refused]")
       end
 
-      it 'does not fall back to raw RubyLLM' do
+      it 'does not fall back to a raw provider client' do
         expect(screen.instance_variable_get(:@llm_chat)).to be_nil
         screen.send(:send_to_llm, 'hello')
       end

--- a/spec/legion/tty/screens/extensions_spec.rb
+++ b/spec/legion/tty/screens/extensions_spec.rb
@@ -181,6 +181,18 @@ RSpec.describe Legion::TTY::Screens::Extensions do
       expect(result.first[:category]).to eq('AI')
     end
 
+    it 'categorizes future native lex-llm provider gems as AI' do
+      spec = double('Gem::Specification',
+                    name: 'lex-llm-future-provider',
+                    version: Gem::Version.new('0.1.0'),
+                    summary: 'Future LLM provider',
+                    homepage: nil,
+                    runtime_dependencies: [])
+      allow(Gem::Specification).to receive(:select).and_return([spec])
+      result = screen.discover_extensions
+      expect(result.first[:category]).to eq('AI')
+    end
+
     it 'categorizes lex-llm-gateway as legacy compatibility' do
       allow(Gem::Specification).to receive(:select).and_return([mock_spec_llm_gateway])
       result = screen.discover_extensions

--- a/spec/legion/tty/screens/extensions_spec.rb
+++ b/spec/legion/tty/screens/extensions_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe Legion::TTY::Screens::Extensions do
            runtime_dependencies: [])
   end
 
+  let(:mock_spec_llm_openai) do
+    double('Gem::Specification',
+           name: 'lex-llm-openai',
+           version: Gem::Version.new('0.1.0'),
+           summary: 'OpenAI LLM provider',
+           homepage: 'https://github.com/LegionIO/lex-llm-openai',
+           runtime_dependencies: [])
+  end
+
+  let(:mock_spec_llm_gateway) do
+    double('Gem::Specification',
+           name: 'lex-llm-gateway',
+           version: Gem::Version.new('0.3.0'),
+           summary: 'Legacy LLM gateway compatibility',
+           homepage: 'https://github.com/LegionIO/lex-llm-gateway',
+           runtime_dependencies: [])
+  end
+
   let(:mock_spec_agentic) do
     double('Gem::Specification',
            name: 'lex-agentic-attention',
@@ -155,6 +173,18 @@ RSpec.describe Legion::TTY::Screens::Extensions do
       allow(Gem::Specification).to receive(:select).and_return([mock_spec_claude])
       result = screen.discover_extensions
       expect(result.first[:category]).to eq('AI')
+    end
+
+    it 'categorizes a native lex-llm provider gem as AI' do
+      allow(Gem::Specification).to receive(:select).and_return([mock_spec_llm_openai])
+      result = screen.discover_extensions
+      expect(result.first[:category]).to eq('AI')
+    end
+
+    it 'categorizes lex-llm-gateway as legacy compatibility' do
+      allow(Gem::Specification).to receive(:select).and_return([mock_spec_llm_gateway])
+      result = screen.discover_extensions
+      expect(result.first[:category]).to eq('Legacy')
     end
 
     it 'categorizes a Service gem correctly' do


### PR DESCRIPTION
## Summary
- route Background::LlmProbe provider validation through Legion::LLM.ask instead of RubyLLM.chat
- preserve configured provider/model probe inputs and configured fallback status on failures
- categorize native lex-llm provider gems as AI extensions and show lex-llm-gateway as legacy compatibility in the extensions screen
- bump legion-tty to 0.5.4 and add changelog entry

## Verification
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A