### PR TITLE
Migrate Teams auth + identity probes to lex-identity extensions (#29, #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.6] - 2026-07-02
+
+### Changed
+- **Probes route through identity provider extensions** — `Background::KerberosProbe` now resolves the principal via `lex-identity-kerberos` `Helpers::Resolver` when loaded, falling back to inline `klist` parsing for TTY-only mode. `Background::GitHubProbe` now resolves its token via `lex-identity-github` `Helpers::TokenResolver` when loaded, falling back to the inline env-var + `gh` CLI path. Both degrade gracefully when the identity gems are unavailable (closes #26)
+
 ## [0.5.5] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.5] - 2026-07-02
+
+### Fixed
+- **Teams onboarding auth crash** — onboarding no longer requires the deleted `lex-microsoft_teams` `Helpers::TokenCache` / `Helpers::BrowserAuth`, which were migrated to `lex-identity-entra`. `build_teams_browser_auth`, `store_teams_token`, and `teams_already_authenticated?` now route through `Legion::Extensions::Identity::Entra::Helpers::{BrowserAuth,TokenManager,Scopes}`, matching the entra delegated CLI login flow (closes #29)
+
 ## [0.5.4] - 2026-04-28
 
 ### Fixed

--- a/lib/legion/tty/background/github_probe.rb
+++ b/lib/legion/tty/background/github_probe.rb
@@ -287,6 +287,9 @@ module Legion
         # --- Token resolution ---
 
         def resolve_token
+          identity_token = token_from_identity
+          return identity_token if identity_token
+
           env_token = ENV.fetch('GITHUB_TOKEN', nil) ||
                       ENV.fetch('GH_TOKEN', nil) ||
                       ENV.fetch('GITHUB_PERSONAL_ACCESS_TOKEN', nil)
@@ -302,6 +305,21 @@ module Legion
           end
 
           @boot_log&.log('github', 'no token found (no env var, no gh CLI)')
+          nil
+        end
+
+        # Prefer the shared lex-identity-github token resolver (env + gh CLI,
+        # multi-account aware); fall back to inline resolution for TTY-only mode
+        # where the identity extension isn't loaded.
+        def token_from_identity
+          require 'legion/extensions/identity/github/helpers/token_resolver'
+          resolved = Legion::Extensions::Identity::Github::Helpers::TokenResolver.resolve_default
+          return nil unless resolved.is_a?(Hash) && resolved[:token]
+
+          @boot_log&.log('github', "token source: lex-identity-github (#{resolved[:source]})")
+          resolved[:token]
+        rescue LoadError, StandardError => e
+          @boot_log&.log('github', "identity resolver unavailable: #{e.message}")
           nil
         end
 

--- a/lib/legion/tty/background/kerberos_probe.rb
+++ b/lib/legion/tty/background/kerberos_probe.rb
@@ -14,7 +14,7 @@ module Legion
         end
 
         def probe
-          principal = read_principal
+          principal = resolve_principal
           return nil unless principal
 
           username = principal.split('@', 2).first
@@ -39,6 +39,25 @@ module Legion
         end
 
         private
+
+        # Prefer the shared lex-identity-kerberos resolver (reads the principal
+        # from Legion::Crypt); fall back to parsing `klist` directly for TTY-only
+        # mode where the identity extension isn't loaded.
+        def resolve_principal
+          identity_principal || read_principal
+        end
+
+        def identity_principal
+          require 'legion/extensions/identity/kerberos/helpers/resolver'
+          principal = Legion::Extensions::Identity::Kerberos::Helpers::Resolver.principal
+          return nil if principal.nil? || principal.to_s.empty?
+
+          @log&.log('kerberos', "principal source: lex-identity-kerberos (#{principal})")
+          principal.to_s
+        rescue LoadError, StandardError => e
+          @log&.log('kerberos', "identity resolver unavailable: #{e.message}")
+          nil
+        end
 
         def read_principal
           output = `klist 2>/dev/null`

--- a/lib/legion/tty/screens/onboarding.rb
+++ b/lib/legion/tty/screens/onboarding.rb
@@ -359,14 +359,15 @@ module Legion
           @output.puts
           browser_auth = build_teams_browser_auth
           result = browser_auth.authenticate
-          if result && result[:access_token]
-            store_teams_token(result)
+          body = result.is_a?(Hash) ? result[:result] : nil
+          if body && body[:access_token]
+            store_teams_token(body)
             typed_output('Teams connected.')
           else
             typed_output('Teams connection skipped.')
           end
           @output.puts
-        rescue StandardError => e
+        rescue LoadError, StandardError => e
           typed_output("Teams connection failed: #{e.message}")
           @output.puts
         end
@@ -393,29 +394,50 @@ module Legion
         end
 
         def teams_already_authenticated?
-          File.exist?(File.expand_path('~/.legionio/tokens/microsoft_teams.json'))
+          require 'legion/extensions/identity/entra/helpers/token_manager'
+          Legion::Extensions::Identity::Entra::Helpers::TokenManager.authenticated?(:delegated)
+        rescue LoadError, StandardError => e
+          log.debug { "teams_already_authenticated? failed: #{e.message}" }
+          false
         end
 
         def build_teams_browser_auth
-          require 'legion/extensions/microsoft_teams/helpers/browser_auth'
-          settings = begin
-            Legion::Settings.dig(:microsoft_teams, :auth) || {}
-          rescue StandardError => e
-            log.warn { "build_teams_browser_auth settings failed: #{e.message}" }
-            {}
-          end
-          Legion::Extensions::MicrosoftTeams::Helpers::BrowserAuth.new(
+          require 'legion/extensions/identity/entra/helpers/browser_auth'
+          settings = teams_entra_settings
+          Legion::Extensions::Identity::Entra::Helpers::BrowserAuth.new(
             tenant_id: settings[:tenant_id],
-            client_id: settings[:client_id]
+            client_id: settings[:client_id],
+            scopes: teams_scopes,
+            force_local_server: true
           )
         end
 
-        def store_teams_token(result)
-          require 'legion/extensions/microsoft_teams/helpers/token_cache'
-          cache = Legion::Extensions::MicrosoftTeams::Helpers::TokenCache.instance
-          cache.store_delegated_token(result)
-          cache.save_to_vault
-        rescue StandardError => e
+        def teams_entra_settings
+          require 'legion/extensions/identity/entra/helpers/token_manager'
+          Legion::Extensions::Identity::Entra::Helpers::TokenManager.settings_auth
+        rescue LoadError, StandardError => e
+          log.warn { "teams_entra_settings failed: #{e.message}" }
+          {}
+        end
+
+        def teams_scopes
+          require 'legion/extensions/identity/entra/helpers/scopes'
+          Legion::Extensions::Identity::Entra::Helpers::Scopes.resolve(pattern: :delegated)
+        rescue LoadError, StandardError => e
+          log.warn { "teams_scopes failed: #{e.message}" }
+          nil
+        end
+
+        def store_teams_token(body)
+          require 'legion/extensions/identity/entra/helpers/token_manager'
+          Legion::Extensions::Identity::Entra::Helpers::TokenManager.save_token(
+            :delegated,
+            access_token: body[:access_token],
+            refresh_token: body[:refresh_token],
+            expires_in: body[:expires_in] || 3600,
+            scopes: body[:scope] || teams_scopes
+          )
+        rescue LoadError, StandardError => e
           log.warn { "store_teams_token failed: #{e.message}" }
           nil
         end

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.5.4'
+    VERSION = '0.5.5'
   end
 end

--- a/lib/legion/tty/version.rb
+++ b/lib/legion/tty/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module TTY
-    VERSION = '0.5.5'
+    VERSION = '0.5.6'
   end
 end

--- a/spec/legion/tty/background/github_probe_spec.rb
+++ b/spec/legion/tty/background/github_probe_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe Legion::TTY::Background::GitHubProbe do
     end
   end
 
+  describe 'resolve_token (private)' do
+    subject(:probe) { described_class.new(token: nil) }
+
+    it 'prefers the lex-identity-github resolver when it returns a token' do
+      allow(probe).to receive(:token_from_identity).and_return('identity-token')
+      expect(probe.send(:resolve_token)).to eq('identity-token')
+    end
+
+    it 'falls back to ENV when the identity resolver yields nothing' do
+      allow(probe).to receive(:token_from_identity).and_return(nil)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('GITHUB_TOKEN', nil).and_return('env-token')
+      expect(probe.send(:resolve_token)).to eq('env-token')
+    end
+
+    it 'returns nil gracefully when the identity gem is unavailable' do
+      # lex-identity-github is not part of the TTY test bundle, so the require
+      # raises LoadError and token_from_identity degrades to nil.
+      expect(probe.send(:token_from_identity)).to be_nil
+    end
+  end
+
   describe 'infer_username (private)' do
     it 'extracts username from HTTPS URL' do
       url = 'https://github.com/LegionIO/legion-tty'

--- a/spec/legion/tty/background/kerberos_probe_spec.rb
+++ b/spec/legion/tty/background/kerberos_probe_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe Legion::TTY::Background::KerberosProbe do
     end
   end
 
+  describe 'resolve_principal (private)' do
+    it 'prefers the lex-identity-kerberos resolver when it returns a principal' do
+      allow(probe).to receive(:identity_principal).and_return('kdoe@CORP.EXAMPLE.COM')
+      expect(probe).not_to receive(:read_principal)
+      expect(probe.send(:resolve_principal)).to eq('kdoe@CORP.EXAMPLE.COM')
+    end
+
+    it 'falls back to klist when the identity resolver yields nothing' do
+      allow(probe).to receive(:identity_principal).and_return(nil)
+      allow(probe).to receive(:read_principal).and_return('jdoe@EXAMPLE.COM')
+      expect(probe.send(:resolve_principal)).to eq('jdoe@EXAMPLE.COM')
+    end
+
+    it 'returns nil gracefully when the identity gem is unavailable' do
+      # lex-identity-kerberos is not part of the TTY test bundle, so the require
+      # raises LoadError and identity_principal degrades to nil.
+      expect(probe.send(:identity_principal)).to be_nil
+    end
+  end
+
   describe 'private methods' do
     describe 'realm_to_base_dn' do
       it 'converts realm to LDAP base DN' do

--- a/spec/legion/tty/daemon_client_spec.rb
+++ b/spec/legion/tty/daemon_client_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe Legion::TTY::DaemonClient do
 
   describe '.chat' do
     it 'returns nil when daemon is unavailable' do
+      # Simulate an unreachable daemon rather than relying on nothing listening
+      # on 127.0.0.1:4567 — a real LegionIO daemon may be running locally.
+      allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
       result = described_class.chat(message: 'hello')
       expect(result).to be_nil
     end

--- a/spec/legion/tty/screens/onboarding_teams_spec.rb
+++ b/spec/legion/tty/screens/onboarding_teams_spec.rb
@@ -31,10 +31,19 @@ RSpec.describe Legion::TTY::Screens::Onboarding do
 
       it 'runs BrowserAuth when user agrees' do
         allow(wizard).to receive(:confirm).with(/Microsoft Teams/).and_return(true)
-        browser_auth = double('browser_auth', authenticate: { access_token: 'tok' })
+        browser_auth = double('browser_auth', authenticate: { result: { access_token: 'tok' } })
         allow(onboarding).to receive(:build_teams_browser_auth).and_return(browser_auth)
         allow(onboarding).to receive(:store_teams_token)
         expect(browser_auth).to receive(:authenticate)
+        onboarding.send(:run_service_auth)
+      end
+
+      it 'stores the token from the nested result body' do
+        allow(wizard).to receive(:confirm).with(/Microsoft Teams/).and_return(true)
+        body = { access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }
+        browser_auth = double('browser_auth', authenticate: { result: body })
+        allow(onboarding).to receive(:build_teams_browser_auth).and_return(browser_auth)
+        expect(onboarding).to receive(:store_teams_token).with(body)
         onboarding.send(:run_service_auth)
       end
 
@@ -72,10 +81,9 @@ RSpec.describe Legion::TTY::Screens::Onboarding do
   end
 
   describe '#teams_already_authenticated?' do
-    it 'checks for token file existence' do
-      allow(File).to receive(:exist?).and_call_original
-      token_path = File.expand_path('~/.legionio/tokens/microsoft_teams.json')
-      allow(File).to receive(:exist?).with(token_path).and_return(false)
+    it 'returns false gracefully when the entra identity gem is unavailable' do
+      # lex-identity-entra is not part of the TTY test bundle, so the require
+      # raises LoadError and the method degrades to false.
       expect(onboarding.send(:teams_already_authenticated?)).to be false
     end
   end


### PR DESCRIPTION
Fixes two stale references to identity logic that moved out of the legacy extensions and into the `lex-identity-*` provider gems.

Each issue has its own commit and its own patch version bump.

## #29 — Teams onboarding auth crash (v0.5.5)

`lex-microsoft_teams` 0.6.52 removed `Helpers::TokenCache` **and** `Helpers::BrowserAuth`, migrating delegated-token storage and browser auth to `lex-identity-entra`. Onboarding still `require`d the deleted files, crashing the service-auth phase with:

```
cannot load such file -- legion/extensions/microsoft_teams/helpers/token_cache
```

(The issue only cited `token_cache`, but `browser_auth` at line 400 was gone too — both are fixed.)

- `build_teams_browser_auth` builds `Entra::Helpers::BrowserAuth` with delegated scopes from `Entra::Helpers::Scopes`
- `store_teams_token` calls `Entra::Helpers::TokenManager.save_token`, reading the token from the nested `:result` body (matching the entra delegated CLI login flow)
- `teams_already_authenticated?` delegates to `TokenManager.authenticated?(:delegated)`
- rescues `LoadError` so TTY-only installs without the entra gem degrade gracefully

## #26 — Migrate probes to identity provider extensions (v0.5.6)

`KerberosProbe` and `GitHubProbe` duplicated logic now living in `lex-identity-kerberos` / `lex-identity-github`. Both now route through the shared provider when loaded, with the inline fallback retained for TTY-only mode:

- `KerberosProbe#probe` → `Identity::Kerberos::Helpers::Resolver.principal`, else inline `klist`
- `GitHubProbe#resolve_token` → `Identity::Github::Helpers::TokenResolver.resolve_default`, else inline env-var + `gh` CLI
- both rescue `LoadError` for graceful degradation

The "Blocked By: lex-identity-github must be deployed" note on #26 is resolved — both identity gems now exist in the monorepo.

## Testing

- Full `bundle exec rspec` suite green (added specs for the new resolver/fallback paths on both probes and the entra-based Teams auth)
- `rubocop` clean (173 files, 0 offenses)
- Also made the `DaemonClient.chat` "daemon unavailable" spec hermetic (stub `Net::HTTP.start`) so it no longer flakes when a real LegionIO daemon is running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)